### PR TITLE
Add repr for QiBackend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Once the provider has been instantiated, it may be used to access supported back
 print(provider.backends())
 
 # Get Quantum Inspire's simulator backend:
-simulator_backend = provider.get_backend("qx_emulator")
+simulator_backend = provider.get_backend("QX emulator")
 ```
 
 ### Submitting a Circuit

--- a/notebooks/sample_notebook_qiskit_qi2.ipynb
+++ b/notebooks/sample_notebook_qiskit_qi2.ipynb
@@ -6,11 +6,19 @@
    "metadata": {},
    "source": [
     "# Sample Notebook to test the Quantum Inspire 2 Qiskit Interface\n",
+<<<<<<< Updated upstream
     "This notebooks illustrates how you can run your qiskit code in the Quantum Inspire 2 platform.\n",
     "### This notebook makes the following assumptions:\n",
     "- quantuminspire2 sdk installed\n",
     "- account exists in the QI2 platform\n",
     "- qiskit plugin installed (pip install qiskit-quantuminspire) in the sam environment as this notebook"
+=======
+    "This notebooks illustrates how you can run your qiskit code on the Quantum Inspire 2 platform.\n",
+    "### This notebook makes the following assumptions:\n",
+    "- quantuminspire2 sdk installed\n",
+    "- account exists in the QI2 platform\n",
+    "- qiskit plugin installed (pip install qiskit-quantuminspire) in the same environment as this notebook"
+>>>>>>> Stashed changes
    ]
   },
   {
@@ -36,7 +44,11 @@
   },
   {
    "cell_type": "code",
+<<<<<<< Updated upstream
    "execution_count": null,
+=======
+   "execution_count": 2,
+>>>>>>> Stashed changes
    "id": "3d4b3950-fe75-47cf-afb5-2286be7c01b4",
    "metadata": {},
    "outputs": [],
@@ -63,11 +75,16 @@
    "source": [
     "provider = QIProvider()\n",
     "\n",
+<<<<<<< Updated upstream
     "backends = []\n",
     "print('The following backends are available:')\n",
     "for backend in provider.backends():\n",
     "    print(f\"ID: [{backend.id}] \\t{backend.name} \")\n",
     "    backends.append(backend)"
+=======
+    "# Show all current supported backends:\n",
+    "print(provider.backends())"
+>>>>>>> Stashed changes
    ]
   },
   {
@@ -76,7 +93,11 @@
    "metadata": {},
    "source": [
     "### Create your Qiskit Circuit\n",
+<<<<<<< Updated upstream
     "Let's create the circuit for the Quantum Approximate Optimization Algorithm (QAOA)"
+=======
+    "Let's create a bell state circuit."
+>>>>>>> Stashed changes
    ]
   },
   {
@@ -88,7 +109,11 @@
    "source": [
     "circuit = QuantumCircuit(3, 10)\n",
     "circuit.h(0)\n",
+<<<<<<< Updated upstream
     "circuit.cnot(0, 1)\n",
+=======
+    "circuit.cx(0, 1)\n",
+>>>>>>> Stashed changes
     "circuit.measure(0, 0)\n",
     "circuit.measure(1, 1)"
    ]
@@ -104,13 +129,23 @@
   },
   {
    "cell_type": "code",
+<<<<<<< Updated upstream
    "execution_count": null,
+=======
+   "execution_count": 13,
+>>>>>>> Stashed changes
    "id": "1f446ddc-7fe6-4731-9840-da1775e10e0f",
    "metadata": {},
    "outputs": [],
    "source": [
+<<<<<<< Updated upstream
     "backend = backends[2]\n",
     "job = backend.run(circuit)"
+=======
+    "\n",
+    "backend = provider.get_backend(name=\"QX emulator\")\n",
+    "job = backend.run(circuit, shots=1024)"
+>>>>>>> Stashed changes
    ]
   },
   {
@@ -119,7 +154,11 @@
    "metadata": {},
    "source": [
     "### Obtain the result \n",
+<<<<<<< Updated upstream
     "After a while the result should be available. Depending on the current load the time for completion may vary."
+=======
+    "After a while the result should be available. Depending on the current load, the time for completion may vary."
+>>>>>>> Stashed changes
    ]
   },
   {
@@ -132,6 +171,7 @@
     "result = job.result()\n",
     "print(result)"
    ]
+<<<<<<< Updated upstream
   },
   {
    "cell_type": "code",
@@ -140,11 +180,17 @@
    "metadata": {},
    "outputs": [],
    "source": []
+=======
+>>>>>>> Stashed changes
   }
  ],
  "metadata": {
   "kernelspec": {
+<<<<<<< Updated upstream
    "display_name": "Python 3 (ipykernel)",
+=======
+   "display_name": "qiskit-quantuminspire-C0W6c0G_-py3.12",
+>>>>>>> Stashed changes
    "language": "python",
    "name": "python3"
   },
@@ -158,7 +204,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
+<<<<<<< Updated upstream
    "version": "3.9.0"
+=======
+   "version": "3.12.5"
+>>>>>>> Stashed changes
   }
  },
  "nbformat": 4,

--- a/notebooks/sample_notebook_qiskit_qi2.ipynb
+++ b/notebooks/sample_notebook_qiskit_qi2.ipynb
@@ -1,216 +1,156 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "48c6731f-5188-41c1-afc4-123c6ed796ae",
-   "metadata": {},
-   "source": [
-    "# Sample Notebook to test the Quantum Inspire 2 Qiskit Interface\n",
-<<<<<<< Updated upstream
-    "This notebooks illustrates how you can run your qiskit code in the Quantum Inspire 2 platform.\n",
-    "### This notebook makes the following assumptions:\n",
-    "- quantuminspire2 sdk installed\n",
-    "- account exists in the QI2 platform\n",
-    "- qiskit plugin installed (pip install qiskit-quantuminspire) in the sam environment as this notebook"
-=======
-    "This notebooks illustrates how you can run your qiskit code on the Quantum Inspire 2 platform.\n",
-    "### This notebook makes the following assumptions:\n",
-    "- quantuminspire2 sdk installed\n",
-    "- account exists in the QI2 platform\n",
-    "- qiskit plugin installed (pip install qiskit-quantuminspire) in the same environment as this notebook"
->>>>>>> Stashed changes
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "93fe4f56-4ced-41fc-b778-14d6c95e2434",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Be sure to have logged in to the QI2 platform via the SDK. If you have installed it in the same environment as \n",
-    "# this notebook, you may run this cell.\n",
-    "\n",
-    "!qi login \"https://staging.qi2.quantum-inspire.com\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0d8ba9f9-9b38-4a86-9252-0b9b9fcdc83f",
-   "metadata": {},
-   "source": [
-    "### The necessary imports"
-   ]
-  },
-  {
-   "cell_type": "code",
-<<<<<<< Updated upstream
-   "execution_count": null,
-=======
-   "execution_count": 2,
->>>>>>> Stashed changes
-   "id": "3d4b3950-fe75-47cf-afb5-2286be7c01b4",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from qiskit import QuantumCircuit\n",
-    "\n",
-    "from qiskit_quantuminspire.qi_provider import QIProvider"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0b464f03-9573-4c3c-852c-3ea4477b59ec",
-   "metadata": {},
-   "source": [
-    "### What QI Backends are available?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "df119aa6-6b48-43a5-aa68-ecf4f7c0dc38",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "provider = QIProvider()\n",
-    "\n",
-<<<<<<< Updated upstream
-    "backends = []\n",
-    "print('The following backends are available:')\n",
-    "for backend in provider.backends():\n",
-    "    print(f\"ID: [{backend.id}] \\t{backend.name} \")\n",
-    "    backends.append(backend)"
-=======
-    "# Show all current supported backends:\n",
-    "print(provider.backends())"
->>>>>>> Stashed changes
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a9f9b123-9b11-4d62-a4ab-8af8f08f7153",
-   "metadata": {},
-   "source": [
-    "### Create your Qiskit Circuit\n",
-<<<<<<< Updated upstream
-    "Let's create the circuit for the Quantum Approximate Optimization Algorithm (QAOA)"
-=======
-    "Let's create a bell state circuit."
->>>>>>> Stashed changes
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e6bbe6af-9908-46cb-8638-8f29966fbf61",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "circuit = QuantumCircuit(3, 10)\n",
-    "circuit.h(0)\n",
-<<<<<<< Updated upstream
-    "circuit.cnot(0, 1)\n",
-=======
-    "circuit.cx(0, 1)\n",
->>>>>>> Stashed changes
-    "circuit.measure(0, 0)\n",
-    "circuit.measure(1, 1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a638262c-c785-4a4f-9ba2-32cc534225f3",
-   "metadata": {},
-   "source": [
-    "### Create the Job in the Quantum Inspire Platform\n",
-    "On the appropriate backend, you run your circuit. Be aware that if your circuit contains gates that are not supported by the target, compilation errors may arise."
-   ]
-  },
-  {
-   "cell_type": "code",
-<<<<<<< Updated upstream
-   "execution_count": null,
-=======
-   "execution_count": 13,
->>>>>>> Stashed changes
-   "id": "1f446ddc-7fe6-4731-9840-da1775e10e0f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-<<<<<<< Updated upstream
-    "backend = backends[2]\n",
-    "job = backend.run(circuit)"
-=======
-    "\n",
-    "backend = provider.get_backend(name=\"QX emulator\")\n",
-    "job = backend.run(circuit, shots=1024)"
->>>>>>> Stashed changes
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9645611e-bd42-4814-9266-243676877e8d",
-   "metadata": {},
-   "source": [
-    "### Obtain the result \n",
-<<<<<<< Updated upstream
-    "After a while the result should be available. Depending on the current load the time for completion may vary."
-=======
-    "After a while the result should be available. Depending on the current load, the time for completion may vary."
->>>>>>> Stashed changes
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4302f110-e5c1-47ea-8e48-994db317a74c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result = job.result()\n",
-    "print(result)"
-   ]
-<<<<<<< Updated upstream
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0810c385-5cc8-4881-9d98-320da0cfe70e",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-=======
->>>>>>> Stashed changes
-  }
- ],
- "metadata": {
-  "kernelspec": {
-<<<<<<< Updated upstream
-   "display_name": "Python 3 (ipykernel)",
-=======
-   "display_name": "qiskit-quantuminspire-C0W6c0G_-py3.12",
->>>>>>> Stashed changes
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-<<<<<<< Updated upstream
-   "version": "3.9.0"
-=======
-   "version": "3.12.5"
->>>>>>> Stashed changes
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "id": "48c6731f-5188-41c1-afc4-123c6ed796ae",
+            "metadata": {},
+            "source": [
+                "# Sample Notebook to test the Quantum Inspire 2 Qiskit Interface\n",
+                "This notebooks illustrates how you can run your qiskit code on the Quantum Inspire 2 platform.\n",
+                "### This notebook makes the following assumptions:\n",
+                "- quantuminspire2 sdk installed\n",
+                "- account exists in the QI2 platform\n",
+                "- qiskit plugin installed (pip install qiskit-quantuminspire) in the same environment as this notebook"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "93fe4f56-4ced-41fc-b778-14d6c95e2434",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Be sure to have logged in to the QI2 platform via the SDK. If you have installed it in the same environment as \n",
+                "# this notebook, you may run this cell.\n",
+                "\n",
+                "!qi login \"https://staging.qi2.quantum-inspire.com\""
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "0d8ba9f9-9b38-4a86-9252-0b9b9fcdc83f",
+            "metadata": {},
+            "source": [
+                "### The necessary imports"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "3d4b3950-fe75-47cf-afb5-2286be7c01b4",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from qiskit import QuantumCircuit\n",
+                "\n",
+                "from qiskit_quantuminspire.qi_provider import QIProvider"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "0b464f03-9573-4c3c-852c-3ea4477b59ec",
+            "metadata": {},
+            "source": [
+                "### What QI Backends are available?"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "df119aa6-6b48-43a5-aa68-ecf4f7c0dc38",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "provider = QIProvider()\n",
+                "\n",
+                "# Show all current supported backends:\n",
+                "print(provider.backends())"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "a9f9b123-9b11-4d62-a4ab-8af8f08f7153",
+            "metadata": {},
+            "source": [
+                "### Create your Qiskit Circuit\n",
+                "Let's create a bell state circuit."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "e6bbe6af-9908-46cb-8638-8f29966fbf61",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "circuit = QuantumCircuit(3, 10)\n",
+                "circuit.h(0)\n",
+                "circuit.cx(0, 1)\n",
+                "circuit.measure(0, 0)\n",
+                "circuit.measure(1, 1)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "a638262c-c785-4a4f-9ba2-32cc534225f3",
+            "metadata": {},
+            "source": [
+                "### Create the Job in the Quantum Inspire Platform\n",
+                "On the appropriate backend, you run your circuit. Be aware that if your circuit contains gates that are not supported by the target, compilation errors may arise."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "1f446ddc-7fe6-4731-9840-da1775e10e0f",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "\n",
+                "backend = provider.get_backend(name=\"QX emulator\")\n",
+                "job = backend.run(circuit, shots=1024)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "9645611e-bd42-4814-9266-243676877e8d",
+            "metadata": {},
+            "source": [
+                "### Obtain the result \n",
+                "After a while the result should be available. Depending on the current load, the time for completion may vary."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "4302f110-e5c1-47ea-8e48-994db317a74c",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "result = job.result()\n",
+                "print(result)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "qiskit-quantuminspire-C0W6c0G_-py3.12",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.12.5"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/qiskit_quantuminspire/qi_backend.py
+++ b/qiskit_quantuminspire/qi_backend.py
@@ -100,6 +100,11 @@ class QIBackend(Backend):  # type: ignore[misc]
     def __repr_pretty__(self, p: PrettyPrinter) -> None:
         p.pprint(f"QIBackend(name={self.name}, id={self.id})")
 
+    def __repr__(self) -> str:
+        module_name = self.__class__.__module__
+        s = f"<{module_name}.{self.__class__.__name__} object at 0x{id(self):x} (name={self.name}, id={self.id})>"
+        return s
+
     @classmethod
     def _default_options(cls) -> Options:
         return Options(shots=1024, optimization_level=1)

--- a/qiskit_quantuminspire/qi_backend.py
+++ b/qiskit_quantuminspire/qi_backend.py
@@ -105,9 +105,6 @@ class QIBackend(Backend):  # type: ignore[misc]
         s = f"<{module_name}.{self.__class__.__name__} object at 0x{id(self):x} (name={self.name}, id={self.id})>"
         return s
 
-    def __repr_pretty__(self, p: PrettyPrinter) -> None:
-        p.pprint(f"QIBackend(name={self.name}, id={self.id})")
-
     @classmethod
     def _default_options(cls) -> Options:
         return Options(shots=1024, optimization_level=1)

--- a/qiskit_quantuminspire/qi_backend.py
+++ b/qiskit_quantuminspire/qi_backend.py
@@ -105,6 +105,9 @@ class QIBackend(Backend):  # type: ignore[misc]
         s = f"<{module_name}.{self.__class__.__name__} object at 0x{id(self):x} (name={self.name}, id={self.id})>"
         return s
 
+    def __repr_pretty__(self, p: PrettyPrinter) -> None:
+        p.pprint(f"QIBackend(name={self.name}, id={self.id})")
+
     @classmethod
     def _default_options(cls) -> Options:
         return Options(shots=1024, optimization_level=1)

--- a/tests/test_qi_backend.py
+++ b/tests/test_qi_backend.py
@@ -87,6 +87,15 @@ def test_qi_backend_construction_max_shots() -> None:
     # Assert
     assert qi_backend.max_shots == 4096
 
+def test_qi_backend_repr() -> None:
+    # Arrange
+    backend_type = create_backend_type(max_number_of_shots=4096)
+
+    # Act
+    qi_backend = QIBackend(backend_type=backend_type)
+
+    # Assert
+    assert qi_backend.name in repr(qi_backend)
 
 def test_qi_backend_construction_toffoli_gate_unsupported(
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_qi_backend.py
+++ b/tests/test_qi_backend.py
@@ -87,6 +87,7 @@ def test_qi_backend_construction_max_shots() -> None:
     # Assert
     assert qi_backend.max_shots == 4096
 
+
 def test_qi_backend_repr() -> None:
     # Arrange
     backend_type = create_backend_type(max_number_of_shots=4096)
@@ -96,6 +97,7 @@ def test_qi_backend_repr() -> None:
 
     # Assert
     assert qi_backend.name in repr(qi_backend)
+
 
 def test_qi_backend_construction_toffoli_gate_unsupported(
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
The printing of the available backends in the example from the README is not very informative, as the representation of the backends contains no other information than the id. We change the `repr` to include the id and name so that the backends are rendered as `<qiskit_quantuminspire.qi_backend.QIBackend object at 0x16bfdce75c0 (name=Spin, id=1)>`

Also change the name of the backend in the example to an existing one.

Notes: instead of changing the repr I would be also happy to add a `__repr_pretty__` which is used in interactive backends like jupyter notebook or spyder.